### PR TITLE
add new api service with two endpoints to create and check the backup status

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,101 @@ Make sure to activate the checkbox on the HDI Container. Only flagged HDI Contai
 
 ![](README/scheduled_flag.PNG)
 
+## Trigger Backups from External Systems (REST API)
+
+A single HDI Container can be backed up from an external system through a public REST API. This API is not protected by XSUAA, it is secured by an API key instead.
+
+### Setup
+
+Generate a random API key, for example:
+```
+openssl rand -base64 32
+```
+
+The API key is read from the `BACKUP_API_KEY` environment variable. Set it as User-Provided Variable on the srv-Application, because variables set by the MTA are cleared on each deployment:
+```
+cf set-env HDI-Backup-srv BACKUP_API_KEY <Generated API Key>
+cf restage HDI-Backup-srv
+```
+
+When running locally, add the same variable to your `.env` file:
+```
+BACKUP_API_KEY=<Generated API Key>
+```
+
+*If `BACKUP_API_KEY` is not set, the API rejects every request with HTTP 503. This way the endpoint is never reachable without a key.*
+
+### Minimum Backup Interval
+
+Two backups of the same HDI Container have to be at least 5 minutes apart. Set the `MIN_BACKUP_INTERVAL_MINUTES` environment variable to change this:
+```
+cf set-env HDI-Backup-srv MIN_BACKUP_INTERVAL_MINUTES 15
+cf restage HDI-Backup-srv
+```
+
+### Endpoint URL
+
+The API is served by the srv-Application directly, not through the AppRouter. Get its URL with:
+```
+cf app HDI-Backup-srv
+```
+
+### Create a Backup
+
+```
+curl -i -X POST https://<srv-app-url>/api/v1/createBackup \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: <Generated API Key>" \
+  -d '{"containerId": "<HDI Container GUID>"}'
+```
+
+A backup takes longer than the usual HTTP timeouts, so it is processed in the background. The call returns immediately:
+```
+HTTP/1.1 202 Accepted
+
+{
+  "backupId": "a1b2c3d4-...",
+  "message": "Backup started, poll backupStatus with the returned backupId"
+}
+```
+
+### Check the Backup Status
+
+```
+curl "https://<srv-app-url>/api/v1/backupStatus?backupId=<backupId>" \
+  -H "x-api-key: <Generated API Key>"
+```
+
+As long as the export is running, the entry does not exist yet:
+```
+{ "backupId": "a1b2c3d4-...", "status": "pending" }
+```
+
+Once the export has finished, the backup details are returned:
+```
+{
+  "backupId": "a1b2c3d4-...",
+  "status": "completed",
+  "created": "2025-01-01T12:00:00.000Z",
+  "path": "MyApp/<HDI Container GUID>/2025-01-01T12:00:00.000Z",
+  "numberOfFiles": 42,
+  "sizeInMB": 128
+}
+```
+
+*Note that a failed backup is not distinguishable from a running one, both are reported as `pending`. Check the application log for details.*
+
+### Response Codes
+
+Status | Meaning
+---------|----------
+`202` | Backup was started, poll `backupStatus` with the returned `backupId`
+`400` | `containerId` is missing
+`401` | `x-api-key` header is missing or invalid
+`404` | No HDI Container exists for the given `containerId`
+`429` | A backup for this HDI Container is still running, or the last one was created less than `MIN_BACKUP_INTERVAL_MINUTES` ago
+`503` | `BACKUP_API_KEY` is not configured on the application
+
 ## Tips and Tricks
 
 ### Access S3 Storage using WinSCP

--- a/mta.yaml
+++ b/mta.yaml
@@ -25,6 +25,8 @@ modules:
       #cds_requires_hanadb_credentials_host: <Connection URL from Hana DB>
       #cds_requires_hanadb_credentials_user: <Backup User's Username>
       #cds_requires_hanadb_credentials_pw: <Backup User's Password>
+      #BACKUP_API_KEY: <Secret API Key for the external REST API>
+      #MIN_BACKUP_INTERVAL_MINUTES: <Minimum minutes between two backups of the same HDI Container, default 5>
     build-parameters:
       builder: npm
       ignore:

--- a/srv/api-service.cds
+++ b/srv/api-service.cds
@@ -1,0 +1,33 @@
+/**
+ * Public REST API to trigger backups from external systems.
+ * Not protected by XSUAA, but requires the API key from the BACKUP_API_KEY environment variable
+ * to be sent in the 'x-api-key' request header.
+ */
+@path    : '/api/v1'
+@protocol: 'rest'
+@requires: 'any'
+service ApiService {
+
+  /**
+   * Test with POST http://localhost:4004/api/v1/createBackup
+   * Header: x-api-key: <BACKUP_API_KEY>
+   * Body: { "containerId": "<HDI Container GUID>" }
+   */
+  action createBackup(containerId : String) returns {
+    backupId : String;
+    message  : String;
+  };
+
+  /**
+   * Test with GET http://localhost:4004/api/v1/backupStatus?backupId=<ID>
+   * Header: x-api-key: <BACKUP_API_KEY>
+   */
+  function backupStatus(backupId : String) returns {
+    backupId      : String;
+    status        : String;
+    created       : DateTime;
+    path          : String;
+    numberOfFiles : Integer;
+    sizeInMB      : Integer;
+  };
+}

--- a/srv/api-service.js
+++ b/srv/api-service.js
@@ -1,0 +1,183 @@
+const cds = require('@sap/cds');
+const crypto = require('crypto');
+
+const { HDIContainers, Backups } = cds.entities('my');
+const { uuid } = cds.utils;
+
+const CatalogService = require('./cat-service');
+
+const LOG = cds.log('custom');
+
+const DEFAULT_MIN_BACKUP_INTERVAL_MINUTES = 5;
+
+/**
+ * Minimum time that has to pass between two backups of the same HDI Container.
+ * Configurable via the MIN_BACKUP_INTERVAL_MINUTES environment variable.
+ */
+const MIN_BACKUP_INTERVAL_MINUTES = Number(process.env.MIN_BACKUP_INTERVAL_MINUTES) || DEFAULT_MIN_BACKUP_INTERVAL_MINUTES;
+const MIN_BACKUP_INTERVAL_MS = MIN_BACKUP_INTERVAL_MINUTES * 60 * 1000;
+
+/**
+ * Backups that are currently running, keyed by HDI Container GUID.
+ * Needed because the Backups entry is only written once the export has finished,
+ * so the database check alone cannot detect a backup that is still in progress.
+ * Only effective per application instance.
+ */
+const runningBackups = new Map();
+
+/**
+ * Compare the provided API key against the expected one without leaking timing information.
+ * Both values are hashed first so that the comparison is independent of the key length.
+ * @param {String} providedApiKey API key sent by the caller
+ * @param {String} expectedApiKey API key configured for this application
+ * @returns {Boolean} TRUE if both keys match
+ */
+function _isValidApiKey(providedApiKey, expectedApiKey) {
+  const provided = crypto.createHash('sha256').update(providedApiKey).digest();
+  const expected = crypto.createHash('sha256').update(expectedApiKey).digest();
+
+  return crypto.timingSafeEqual(provided, expected);
+}
+
+class ApiService extends cds.ApplicationService {
+  init() {
+
+    /**
+     * This service is reachable without authentication, so every request has to present the API key.
+     */
+    this.before('*', (req) => {
+      const expectedApiKey = process.env.BACKUP_API_KEY;
+
+      if (!expectedApiKey) {
+        LOG.error('BACKUP_API_KEY is not configured, rejecting external API request');
+        return req.reject(503, 'External API is not configured');
+      }
+
+      const providedApiKey = req.headers['x-api-key'];
+
+      if (!providedApiKey || !_isValidApiKey(providedApiKey, expectedApiKey)) {
+        LOG.warn('External API request rejected because of a missing or invalid API key');
+        return req.reject(401, 'Invalid API key');
+      }
+    });
+
+    /**
+     * Create a Backup of a single HDI Container.
+     * The backup itself runs in the background, the returned backupId can be polled via backupStatus.
+     */
+    this.on('createBackup', async (req) => {
+      /**
+       * Make sure HDI container exists and is valid
+       */
+      const { containerId } = req.data;
+      LOG.debug('Create Backup by External API', containerId);
+
+      if (!containerId) {
+        return req.reject(400, 'Parameter containerId is required');
+      }
+
+      const hdiContainer = await SELECT.one.from(HDIContainers, hdiContainer => {
+        hdiContainer('*'),
+          hdiContainer.application('*')
+      }).where({ containerId });
+
+      if (!hdiContainer) {
+        return req.reject(404, `HDI Container ${containerId} not found`);
+      }
+
+      /**
+       * Prevent starting a backup if one is already running for the same HDI Container or if the last backup was created too recently.
+       * The time between two backups is configurable via the MIN_BACKUP_INTERVAL_MINUTES environment variable, defaulting to 5 minutes.
+       */
+      const runningSince = runningBackups.get(containerId);
+      if (runningSince) {
+        return req.reject(429, `A backup for HDI Container ${containerId} has already been running since ${runningSince.toISOString()}`);
+      }
+
+      const lastBackup = await SELECT.one.from(Backups)
+        .where({ hdiContainer_containerId: containerId })
+        .orderBy('created desc');
+
+      if (lastBackup?.created) {
+        const msSinceLastBackup = Date.now() - new Date(lastBackup.created).getTime();
+
+        if (msSinceLastBackup < MIN_BACKUP_INTERVAL_MS) {
+          const retryAfterSeconds = Math.ceil((MIN_BACKUP_INTERVAL_MS - msSinceLastBackup) / 1000);
+          return req.reject(429, `Last backup for HDI Container ${containerId} was created less than ${MIN_BACKUP_INTERVAL_MINUTES} minutes ago, retry in ${retryAfterSeconds} seconds`);
+        }
+      }
+      
+      /**
+       * Check if the S3 Bucket is available before starting the backup, otherwise the backup will fail anyway.
+       */
+      await CatalogService._checkS3Bucket();
+      LOG.debug('S3 Bucket is available');
+
+      const backupId = uuid();
+      runningBackups.set(containerId, new Date());
+
+      /**
+       * A backup takes far longer than the usual HTTP timeouts, so it is processed in the background.
+       * The caller polls the result via the backupStatus function using the returned backupId.
+       */
+      cds.spawn(async () => {
+        try {
+          // _createBackup reports failures via req.error instead of throwing, so compare the result
+          const result = await CatalogService._createBackup(hdiContainer, req, false, backupId);
+
+          if (result === backupId) {
+            LOG.info(`Backup ${backupId} for HDI Container ${containerId} created successfully`);
+          } else {
+            LOG.error(`Backup ${backupId} for HDI Container ${containerId} failed`, req.errors);
+          }
+        } catch (err) {
+          LOG.error(`Backup ${backupId} for HDI Container ${containerId} failed`, err);
+        } finally {
+          runningBackups.delete(containerId);
+        }
+      });
+
+      let { res } = req.http;
+      res.status(202).json({
+        backupId: backupId,
+        message: 'Backup started, poll backupStatus with the returned backupId'
+      });
+    });
+
+    /**
+     * Get the status of a Backup that was triggered via this API.
+     * The Backups entry is only written once the export has finished, so a missing entry
+     * means that the backup is either still running or has failed.
+     */
+    this.on('backupStatus', async (req) => {
+      const { backupId } = req.data;
+      LOG.debug('Get Backup Status by External API', backupId);
+
+      if (!backupId) {
+        return req.reject(400, 'Parameter backupId is required');
+      }
+
+      const backup = await SELECT.one.from(Backups).where({ ID: backupId });
+
+      if (!backup) {
+        return {
+          backupId: backupId,
+          status: 'pending'
+        };
+      }
+
+      return {
+        backupId: backup.ID,
+        status: 'completed',
+        created: backup.created,
+        path: backup.path,
+        numberOfFiles: backup.numberOfFiles,
+        sizeInMB: backup.sizeInMB
+      };
+    });
+
+    return super.init();
+  }
+};
+
+module.exports = { ApiService }

--- a/srv/cat-service.js
+++ b/srv/cat-service.js
@@ -52,9 +52,10 @@ async function _checkS3Bucket() {
  * @param {CatalogService.HDIContainers} hdiContainer HDIContainer Entity with expanded Applications
  * @param {cds.Request} req CAP CDS Request Object (used for returning error messages)
  * @param {Boolean} bScheduled TRUE if run by scheduler (Default FALSE)
- * @returns 
+ * @param {String} backupId ID of the Backup entry, can be passed in to know the ID before the backup has finished
+ * @returns {String} ID of the created Backup entry
  */
-async function _createBackup(hdiContainer, req, bScheduled = false) {
+async function _createBackup(hdiContainer, req, bScheduled = false, backupId = uuid()) {
 
   LOG.debug(`Create Backup for HDI Container`, JSON.stringify(hdiContainer));
 
@@ -127,7 +128,7 @@ async function _createBackup(hdiContainer, req, bScheduled = false) {
   LOG.debug(`Size of Backup is ${folderSizeInMB.toFixed(2)} MB`);
 
   let newBackupEntry = {
-    ID: uuid(),
+    ID: backupId,
     created: createdTimestamp,
     hdiContainer_containerId: hdiContainer.containerId,
     path: awsS3FolderPath,
@@ -142,6 +143,8 @@ async function _createBackup(hdiContainer, req, bScheduled = false) {
   LOG.debug('Insert new Backup result', insertResult);
 
   conn.disconnect();
+
+  return backupId;
 }
 
 class CatalogService extends cds.ApplicationService {

--- a/srv/scheduler-service.js
+++ b/srv/scheduler-service.js
@@ -4,7 +4,6 @@ const axios = require('axios');
 const { HDIContainers } = cds.entities('my');
 
 const CatalogService = require('./cat-service');
-const { request } = require('express');
 
 const LOG = cds.log('cds');
 
@@ -21,7 +20,7 @@ class SchedulerService extends cds.ApplicationService {
   init() {
 
     /**
-     * Test with GET http://localhost:4004/odata/v4/scheduler/createBackups(apiKey=1234567890)
+     * Test with GET http://localhost:4004/odata/v4/scheduler/createBackups()
      */
     this.on('createBackups', async (req) => {
       LOG.debug('Create Backup by Scheduler Function');


### PR DESCRIPTION
Added `/api/v1/createBackup` and `/api/v1/backupStatus` endpoints:

**Create a new backup**
```
curl -i -X POST https://<srv-app-url>/api/v1/createBackup \
  -H "Content-Type: application/json" \
  -H "x-api-key: <Generated API Key>" \
  -d '{"containerId": "<HDI Container GUID>"}'
```

**Check the status of the backup**
```
curl "https://<srv-app-url>/api/v1/backupStatus?backupId=<backupId>" \
  -H "x-api-key: <Generated API Key>"
```